### PR TITLE
Saisies agrégées au préleveur ou au point de prélèvement

### DIFF
--- a/lib/models/saisie-journaliere.js
+++ b/lib/models/saisie-journaliere.js
@@ -70,3 +70,59 @@ export async function getSaisiesJournalieres({preleveurId, pointId}, {from, to},
 
   return query.toArray()
 }
+
+export async function getAggregatedSaisiesJournalieresByPreleveur(preleveurId, {from, to}) {
+  if (!preleveurId || !from || !to) {
+    throw new Error('Missing argument')
+  }
+
+  const matchQuery = {
+    preleveur: preleveurId,
+    date: {$gte: from, $lte: to}
+  }
+
+  const pipeline = [
+    {$match: matchQuery},
+    {$group: {
+      _id: '$date',
+      points: {$addToSet: '$point'},
+      volumePreleveTotal: {$sum: '$data.values.volume prélevé'}
+    }}
+  ]
+
+  const items = await mongo.db.collection('saisies_journalieres').aggregate(pipeline).toArray()
+
+  return items.map(item => ({
+    date: item._id,
+    points: item.points,
+    data: {values: {'volume prélevé': item.volumePreleveTotal}}
+  }))
+}
+
+export async function getAggregatedSaisiesJournalieresByPoint(pointId, {from, to}) {
+  if (!pointId || !from || !to) {
+    throw new Error('Missing argument')
+  }
+
+  const matchQuery = {
+    point: pointId,
+    date: {$gte: from, $lte: to}
+  }
+
+  const pipeline = [
+    {$match: matchQuery},
+    {$group: {
+      _id: '$date',
+      preleveurs: {$addToSet: '$preleveur'},
+      volumePreleveTotal: {$sum: '$data.values.volume prélevé'}
+    }}
+  ]
+
+  const items = await mongo.db.collection('saisies_journalieres').aggregate(pipeline).toArray()
+
+  return items.map(item => ({
+    date: item._id,
+    preleveurs: item.preleveurs,
+    data: {values: {'volume prélevé': item.volumePreleveTotal}}
+  }))
+}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -43,6 +43,12 @@ import {
   getVolumesPreleves
 } from './models/volume-preleve.js'
 
+import {
+  getAggregatedSaisiesJournalieresByPoint,
+  getAggregatedSaisiesJournalieresByPreleveur,
+  getSaisiesJournalieres
+} from './models/saisie-journaliere.js'
+
 import {getTerritoireByToken} from './models/territoire.js'
 
 import {
@@ -278,6 +284,14 @@ async function createRoutes() {
       res.send(deletedPoint)
     }))
 
+  app.route('/points-prelevement/:pointId/saisies-journalieres')
+    .get(w(checkPermissionOnPoint), w(async (req, res) => {
+      const {startDate, endDate} = req.query
+
+      const saisies = await getAggregatedSaisiesJournalieresByPoint(req.point._id, {from: startDate, to: endDate})
+      res.send(saisies)
+    }))
+
   app.get('/points-prelevement/:pointId/exploitations', w(checkPermissionOnPoint), w(async (req, res) => {
     const exploitations = await getExploitationsFromPointId(req.point._id)
 
@@ -375,6 +389,14 @@ async function createRoutes() {
       const deletedPreleveur = await deletePreleveur(req.preleveur._id)
 
       res.send(deletedPreleveur)
+    }))
+
+  app.route('/preleveurs/:preleveurId/saisies-journalieres')
+    .get(w(checkPermissionOnPreleveur), w(async (req, res) => {
+      const {startDate, endDate} = req.query
+
+      const saisies = await getAggregatedSaisiesJournalieresByPreleveur(req.preleveur._id, {from: startDate, to: endDate})
+      res.send(saisies)
     }))
 
   app.get('/preleveurs/:preleveurId/points-prelevement', w(checkPermissionOnPreleveur), w(async (req, res) => {

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -40,6 +40,12 @@ class Mongo {
       {preleveur: 1, point: 1, date: 1},
       {unique: true}
     )
+    await mongo.db.collection('saisies_journalieres').createIndex(
+      {preleveur: 1, date: 1}
+    )
+    await mongo.db.collection('saisies_journalieres').createIndex(
+      {point: 1, date: 1}
+    )
   }
 
   disconnect(force) {


### PR DESCRIPTION
This pull request introduces new aggregation endpoints and supporting functions to efficiently retrieve daily sampling data grouped by either sampler (`preleveur`) or sampling point. It also adds relevant database indexes to optimize these queries.

**API enhancements:**

* Added two new endpoints:
  - [`GET /points-prelevement/:pointId/saisies-journalieres`](diffhunk://#diff-2119cae306240011c3c05c96fe0436eacf198677b4dc0cbe99d644a00bfbcdf4R287-R294): Returns daily aggregated sampling data for a given point, including total sampled volume and involved samplers.
  - [`GET /preleveurs/:preleveurId/saisies-journalieres`](diffhunk://#diff-2119cae306240011c3c05c96fe0436eacf198677b4dc0cbe99d644a00bfbcdf4R394-R401): Returns daily aggregated sampling data for a given sampler, including total sampled volume and involved points.

**Data aggregation logic:**

* Implemented `getAggregatedSaisiesJournalieresByPreleveur` and `getAggregatedSaisiesJournalieresByPoint` in `saisie-journaliere.js` to perform MongoDB aggregations by date, calculating total sampled volume and grouping related entities.
* Updated imports in `routes.js` to include new aggregation functions.

**Database optimization:**

* Added indexes on `{preleveur, date}` and `{point, date}` in the `saisies_journalieres` collection to improve aggregation performance for the new endpoints.